### PR TITLE
Guarding against nil value when parsing

### DIFF
--- a/Sources/MDText/MDText.swift
+++ b/Sources/MDText/MDText.swift
@@ -255,8 +255,9 @@ final class MDTextVM: ObservableObject {
             } ?? []
         
         let resultGroups: [MDTextGroup] =  zippedRanges.flatMap{ (next, current) -> [MDTextGroup] in
-            let matchStr = String(string[Range(current, in: string)!])
-            
+            guard let range = Range(current, in: string) else { return [] }
+            let matchStr = String(string[range])
+
             let lowerBound = String.Index(utf16Offset: current.upperBound, in: string)
             let upperBound = String.Index(utf16Offset: next.lowerBound, in: string)
             


### PR DESCRIPTION
Removing force-wrapping which causes app crash when value is nil (I experienced it during development)