### PR TITLE
(bugfix) Update UIApplication.shared.openURL to .open

### DIFF
--- a/Sources/MDText/MDText.swift
+++ b/Sources/MDText/MDText.swift
@@ -63,7 +63,7 @@ struct MDViewGroup: Identifiable {
         print(urlStr)
         guard let url = URL(string: urlStr) else { return }
         #if os(iOS)
-        UIApplication.shared.openURL(url, options: [:])
+		UIApplication.shared.open(url, options: [:])
         #elseif os(macOS)
         NSWorkspace.shared.open(url)
         #endif
@@ -232,7 +232,7 @@ final class MDTextVM: ObservableObject {
         return Button(action: {
             guard let url = URL(string: textGroup.string) else { return }
             #if os(iOS)
-            UIApplication.shared.openURL(url, options: [:])
+			UIApplication.shared.open(url, options: [:])
             #elseif os(macOS)
             NSWorkspace.shared.open(url)
             #endif


### PR DESCRIPTION
`UIApplication.shared.openURL(...)` has now been renamed to `UIApplication.shared.open(...)` in new versions of Swift.

Under some conditions, this will cause the app fail to build